### PR TITLE
Add createTestEvolu, a function that allows for using in-memory Sqlite for unit tests.

### DIFF
--- a/packages/evolu-common/package.json
+++ b/packages/evolu-common/package.json
@@ -48,6 +48,7 @@
     "build": "rm -rf dist ./README.md && tsc && cp ../../README.md ./",
     "lint": "eslint src --ext .ts,.tsx",
     "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf .turbo node_modules dist",
     "format": "prettier --write \"src/*.{ts,tsx,md}\"",
     "protobuf": "pnpm protoc --ts_out ./src --proto_path protobuf protobuf/Protobuf.proto --ts_opt eslint_disable --ts_opt optimize_code_size && pnpm format"

--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -521,7 +521,7 @@ export class EvoluFactory extends Context.Tag("EvoluFactory")<
           };
           let evolu = instances.get(name);
           if (evolu == null) {
-            evolu = createEvolu(
+            evolu = createEvoluEffect(
               dbSchema,
               runtime,
               initialData as EvoluConfig["initialData"],
@@ -596,12 +596,12 @@ const getPropertySignatures = <I extends { [K in keyof A]: any }, A>(
   return out as any;
 };
 
-const createEvolu = (
+export const createEvoluEffect = (
   schema: DbSchema,
   runtime: ManagedRuntime.ManagedRuntime<Config, never>,
   initialData: EvoluConfig["initialData"],
   mnemonic: Mnemonic | undefined,
-) =>
+): Effect.Effect<Evolu<EvoluSchema>, never, Config | DbFactory | AppState | NanoIdGenerator | FlushSync> =>
   Effect.gen(function* () {
     yield* Effect.logTrace("EvoluFactory createEvolu");
     const config = yield* Config;

--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -569,7 +569,7 @@ export interface EvoluConfig<T extends EvoluSchema = EvoluSchema>
   mnemonic: Mnemonic;
 }
 
-const schemaToTables = (schema: S.Schema<any>) =>
+export const schemaToTables = (schema: S.Schema<any>): Table[] =>
   pipe(
     getPropertySignatures(schema),
     Record.toEntries,
@@ -599,8 +599,8 @@ const getPropertySignatures = <I extends { [K in keyof A]: any }, A>(
 export const createEvoluEffect = (
   schema: DbSchema,
   runtime: ManagedRuntime.ManagedRuntime<Config, never>,
-  initialData: EvoluConfig["initialData"],
-  mnemonic: Mnemonic | undefined,
+  initialData?: EvoluConfig["initialData"],
+  mnemonic?: Mnemonic,
 ): Effect.Effect<Evolu<EvoluSchema>, never, Config | DbFactory | AppState | NanoIdGenerator | FlushSync> =>
   Effect.gen(function* () {
     yield* Effect.logTrace("EvoluFactory createEvolu");

--- a/packages/evolu-common/src/EvoluTest.ts
+++ b/packages/evolu-common/src/EvoluTest.ts
@@ -1,0 +1,149 @@
+import { Effect, Layer } from "effect";
+import { createRuntime } from "./Config.js";
+import { createDb, DbFactory, DbSchema } from "./Db.js";
+import {
+  createEvoluEffect,
+  Evolu,
+  EvoluConfig,
+  EvoluSchema,
+  schemaToTables,
+} from "./Evolu.js";
+import { createNanoIdGeneratorLive } from "./Crypto.js";
+import { AppState, FlushSync, SyncLock } from "./Platform.js";
+import { Sqlite, SqliteFactory, SqliteRow } from "./Sqlite.js";
+import { Time } from "./Crdt.js";
+import { Sync, SyncFactory } from "./Sync.js";
+import { customAlphabet, nanoid } from "nanoid";
+import { Schema } from "@effect/schema";
+import Database from "better-sqlite3";
+
+const sqliteFromDatabase = (db: Database.Database) => Effect.sync(() => {
+  return Sqlite.of({
+    exec: (query) =>
+      Effect.sync(() => {
+        // Use a prepared statement to tell if the query returns data or not.
+        const prepared = db.prepare(query.sql);
+        const parameters = query.parameters || [];
+
+        const result = prepared.reader
+          ? { rows: prepared.all(parameters) as SqliteRow[], changes: 0 }
+          : { rows: [], changes: prepared.run(parameters).changes };
+
+        return result;
+      }),
+
+    transaction: () => (effect) => effect,
+
+    export: () => Effect.succeed(new Uint8Array()),
+  });
+})
+
+export const SqliteTest = Layer.effect(
+  Sqlite,
+  Effect.gen(function*() {
+    const db = new Database(":memory:");
+
+    const sqlite = yield* sqliteFromDatabase(db);
+
+    return sqlite
+  })
+);
+
+
+const SqliteFactoryTest = Layer.effect(
+  SqliteFactory,
+  Effect.gen(function* () {
+    const hi = yield* Sqlite;
+    return {
+      createSqlite: Effect.succeed(hi),
+    };
+  }).pipe(Effect.provide(SqliteTest)),
+);
+
+/**
+ * Creates a DbFactory effect that wraps the createDb function.
+ * This effect maps the createDb function to a DbFactory instance,
+ * ensuring that the createDb operation is wrapped in an Effect.succeed.
+ */
+const createDbFactoryEffect = createDb.pipe(
+  Effect.map((createDb) =>
+    DbFactory.of({ createDb: Effect.succeed(createDb) }),
+  ),
+);
+
+const DbFactoryTest = Layer.effect(DbFactory, createDbFactoryEffect);
+
+const createSyncTest = Effect.succeed(
+  Sync.of({
+    init: () => Effect.void,
+    sync: (data) =>
+      Effect.succeed({
+        messages: [],
+        merkleTree: data.merkleTree,
+      }),
+  }),
+);
+
+const SyncFactoryTest = Layer.effect(
+  SyncFactory,
+  createSyncTest.pipe(
+    Effect.map((sync) => SyncFactory.of({ createSync: Effect.succeed(sync) })),
+  ),
+);
+
+const AppStateTest = Layer.succeed(
+  AppState,
+  AppState.of({
+    init: () => Effect.succeed({ reset: Effect.void }),
+  }),
+);
+
+const SyncLockTest = Layer.succeed(
+  SyncLock,
+  SyncLock.of({
+    tryAcquire: Effect.succeed({ release: Effect.void }),
+  }),
+);
+
+const NanoidGeneratorTest = createNanoIdGeneratorLive(customAlphabet, nanoid);
+
+const FlushSyncTest = Layer.succeed(FlushSync, () => {});
+
+const DependenciesLayer = Layer.mergeAll(
+  DbFactoryTest.pipe(
+    Layer.provideMerge(SyncLockTest),
+    Layer.provideMerge(SyncFactoryTest),
+    Layer.provideMerge(NanoidGeneratorTest),
+    Layer.provide(SqliteFactoryTest),
+    Layer.provide(Time.Live),
+  ),
+  FlushSyncTest,
+  AppStateTest,
+);
+
+/**
+ * Creates a test instance of Evolu with mocked dependencies for testing purposes.
+ * 
+ * @param tableSchema - The schema definition for the database tables.
+ * @param config - Optional configuration for Evolu, including custom indexes.
+ * @returns An instance of Evolu<T> configured for testing.
+ */
+export function createTestEvolu<T extends EvoluSchema, I>(
+  tableSchema: Schema.Schema<T, I>,
+  config: Partial<EvoluConfig<T>> = {},
+): Evolu<T> {
+  // Create a DbSchema object from the provided table schema and optional indexes
+  const schema = {
+    indexes: config.indexes ?? [],
+    tables: schemaToTables(tableSchema),
+  } satisfies DbSchema;
+
+  // Create a runtime environment based on the provided config
+  const runtime = createRuntime(config);
+
+  // Create and run the Evolu effect with mocked dependencies
+  return createEvoluEffect(schema, runtime).pipe(
+    Effect.provide(DependenciesLayer),
+    runtime.runSync,
+  ) as Evolu<T>;
+}

--- a/packages/evolu-common/test/EvoluTest.test.ts
+++ b/packages/evolu-common/test/EvoluTest.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { createTestEvolu } from "../src/EvoluTest.js";
+import { cast, database, id, NonEmptyString1000, table } from "../src/Model.js";
+import { Schema } from "@effect/schema";
+import { Effect } from "effect";
+import { Evolu } from "../src/Evolu.js";
+
+const todoId = id("Todo");
+const todoTable = table({
+  id: todoId,
+  title: NonEmptyString1000,
+});
+const db = database({
+  todo: todoTable,
+});
+type Database = (typeof db)["Type"];
+
+const createTodo = (name: string, evolu: Evolu<Database>) => {
+  return Effect.gen(function* () {
+    const title = yield* Schema.decode(NonEmptyString1000)("test title");
+    return evolu.create("todo", { title });
+  }).pipe(Effect.runSync);
+};
+
+describe("createTestEvolu", () => {
+  it("creates a testing evolu that works as expected", async () => {
+    const evolu = createTestEvolu(db, {});
+
+    const result = createTodo("test title", evolu);
+
+    const query = evolu.createQuery((db) =>
+      db
+        .selectFrom("todo")
+        .where("isDeleted", "is not", cast(true))
+        .selectAll()
+        .limit(1),
+    );
+    const queryResult = await evolu.loadQuery(query);
+
+    expect(queryResult.row?.id).toEqual(result.id);
+
+    evolu.update("todo", { id: result.id, isDeleted: true });
+
+    expect(await evolu.loadQuery(query)).toMatchObject({ rows: [] });
+  });
+
+  it("creates the database completely new each time", async () => {
+    const evoluOne = createTestEvolu(db, {});
+
+    const todo = createTodo("Test title", evoluOne);
+    const query = evoluOne.createQuery((db) =>
+      db.selectFrom("todo").selectAll(),
+    );
+    const queryResult = await evoluOne.loadQuery(query);
+    expect(queryResult?.row?.id).toEqual(todo.id);
+
+    const evoluTwo = createTestEvolu(db, {});
+
+    const newQuery = evoluTwo.createQuery((db) =>
+      db.selectFrom("todo").selectAll(),
+    );
+    const newQueryResult = await evoluTwo.loadQuery(newQuery);
+
+    expect(newQueryResult.row).toBeUndefined();
+  });
+});


### PR DESCRIPTION
THIS IS A DRAFT, DO NOT MERGE.

Things to note:

- Currently this approach is slower because it does Evolu setup for every single test. Working on an approach where you can 'fork' the database and avoid having to do all the migrations.
- Sync intentionally does not work and is basically a no-op with this. This library is for testing queries and mutations in your code, not for testing that syncing works. 
- Fixed a bug in the code due to a function being defined before it was being used.